### PR TITLE
feat: add build complie annotation for mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,28 @@
-# Overview
+\# Overview
+
 AtomixDB is an mini relational database fully written in Go.
 Main focus was on implementing & understanding working the of database, storage management & transaction handling.
 
-  
-## Table of Contents 
-- [Installation](#installation)  
-- [Features](#features)  
+## Table of Contents
+
+- [Installation](#installation)
+- [Features](#features)
 - [Upcoming Features](#upcoming-features)
 - [Supported Commands](#supported-commands)
-- [Contributing](#contributing) 
-- [License](#license) 
-
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Installation
 
 ### Prerequisites
 
--   [Golang](https://golang.org/dl/) (version 1.17 or later)
--   [Git](https://git-scm.com/downloads)
--   Linux operating system. AtomixDB has been developed and tested on systems like NixOS.
+- [Golang](https://golang.org/dl/) (version 1.17 or later)
+- [Git](https://git-scm.com/downloads)
+- Linux operating system. AtomixDB has been developed and tested on systems like NixOS.
 
 ### Clone the Repository
 
 Clone the repository to your local machine:
-
 
 ```bash
 git clone https://github.com/Sahilb315/AtomixDB.git && cd AtomixDB
@@ -33,8 +32,8 @@ git clone https://github.com/Sahilb315/AtomixDB.git && cd AtomixDB
 
 Build the project using Go:
 
-
 ```bash
+go mod tidy
 go build -o atomixdb
 ```
 
@@ -47,32 +46,30 @@ To start the AtomixDB server, execute:
 ```
 
 ## Features
--   **B+ Tree Storage Engine with Indexing Support**: Enables fast data retrieval, which is critical for database performance, especially in scenarios involving large datasets.
 
--   **Free List Management for Node Reuse**: The database manages a free list to reuse nodes, which is a strategy to optimize storage usage by recycling space from freed nodes. This helps reduce fragmentation and improve disk space efficiency.
+- **B+ Tree Storage Engine with Indexing Support**: Enables fast data retrieval, which is critical for database performance, especially in scenarios involving large datasets.
 
--   **Transaction Support**: AtomixDB supports transactions, ensuring data consistency and integrity through atomic operations.
--   **Concurrent Reads**: The ability to handle concurrent reads enhances performance by allowing multiple users to read data simultaneously without locking issues, making it suitable for read-heavy applications.
+- **Free List Management for Node Reuse**: The database manages a free list to reuse nodes, which is a strategy to optimize storage usage by recycling space from freed nodes. This helps reduce fragmentation and improve disk space efficiency.
 
-
-
+- **Transaction Support**: AtomixDB supports transactions, ensuring data consistency and integrity through atomic operations.
+- **Concurrent Reads**: The ability to handle concurrent reads enhances performance by allowing multiple users to read data simultaneously without locking issues, making it suitable for read-heavy applications.
 
 ## Upcoming Features
 
--   **Query Processing**: Enhancing AtomixDB with query capabilities to support more complex data retrieval and manipulation.
+- **Query Processing**: Enhancing AtomixDB with query capabilities to support more complex data retrieval and manipulation.
 
--   **Bug Fixes**: Ongoing efforts to address and resolve identified bugs to improve stability and reliability.
+- **Bug Fixes**: Ongoing efforts to address and resolve identified bugs to improve stability and reliability.
 
 ## Supported Commands
 
--   **CREATE**
--   **INSERT**
--   **GET**
--   **UPDATE**
--   **DELETE**
--   **BEGIN**
--   **COMMIT**
--   **ABORT**
+- **CREATE**
+- **INSERT**
+- **GET**
+- **UPDATE**
+- **DELETE**
+- **BEGIN**
+- **COMMIT**
+- **ABORT**
 
 ## Contributing
 

--- a/database/mmap_mac.go
+++ b/database/mmap_mac.go
@@ -1,8 +1,12 @@
-//go:build linux || freebsd || openbsd || netbsd || solaris
+//go:build darwin
 
 package database
 
-import "syscall"
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
 
 func mmapFile(fd uintptr, offset int64, length int, prot, flags int) ([]byte, error) {
 	return syscall.Mmap(int(fd), offset, length, prot, flags)
@@ -13,7 +17,9 @@ func unmapFile(data []byte) error {
 }
 
 func fallocateFile(fd uintptr, offset int64, length int64) error {
-	return syscall.Fallocate(int(fd), 0, offset, length)
+	// use mmap let file map to memory
+	_, err := unix.Mmap(int(fd), 0, int(offset+length), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	return err
 }
 
 func pwriteFile(fd uintptr, data []byte, offset int64) (int, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module atomixDB
 
 go 1.23.2
+
+require golang.org/x/sys v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=


### PR DESCRIPTION
Add annotations for macOS compilation to resolve the issue of missing fallocate during compilation on mac machines.





